### PR TITLE
cbor encoder: Add support for {text,byte}string, arrays, maps, and bool

### DIFF
--- a/go/signedexchange/cbor/encoder.go
+++ b/go/signedexchange/cbor/encoder.go
@@ -1,7 +1,15 @@
 package cbor
 
 import (
+	"bytes"
+	"errors"
 	"io"
+	"sort"
+	"unicode/utf8"
+)
+
+var (
+	ErrInvalidUTF8 = errors.New("Cannot encode invalid UTF-8.")
 )
 
 type Encoder struct {
@@ -72,4 +80,138 @@ func (e *Encoder) EncodeInt(n int64) error {
 	       decimal.
 	*/
 	return e.encodeTypedUInt(TypeNegInt, uint64(-n)-1)
+}
+
+func (e Encoder) encodeBytes(t Type, bs []byte) error {
+	if err := e.encodeTypedUInt(t, uint64(len(bs))); err != nil {
+		return err
+	}
+
+	_, err := e.w.Write(bs)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e Encoder) EncodeByteString(bs []byte) error {
+	/*
+	   Major type 2:  a byte string.  The string's length in bytes is
+	       represented following the rules for positive integers (major type
+	       0).  For example, a byte string whose length is 5 would have an
+	       initial byte of 0b010_00101 (major type 2, additional information
+	       5 for the length), followed by 5 bytes of binary content.  A byte
+	       string whose length is 500 would have 3 initial bytes of
+	       0b010_11001 (major type 2, additional information 25 to indicate a
+	       two-byte length) followed by the two bytes 0x01f4 for a length of
+	       500, followed by 500 bytes of binary content.
+	*/
+
+	return e.encodeBytes(TypeBytes, bs)
+}
+
+func (e Encoder) EncodeTextString(s string) error {
+	/*
+	   Major type 3:  a text string, specifically a string of Unicode
+	       characters that is encoded as UTF-8 [RFC3629].  The format of this
+	       type is identical to that of byte strings (major type 2), that is,
+	       as with major type 2, the length gives the number of bytes.  This
+	       type is provided for systems that need to interpret or display
+	       human-readable text, and allows the differentiation between
+	       unstructured bytes and text that has a specified repertoire and
+	       encoding.  In contrast to formats such as JSON, the Unicode
+	       characters in this type are never escaped.  Thus, a newline
+	       character (U+000A) is always represented in a string as the byte
+	       0x0a, and never as the bytes 0x5c6e (the characters "\" and "n")
+	       or as 0x5c7530303061 (the characters "\", "u", "0", "0", "0", and
+	       "a").
+	*/
+	bs := []byte(s)
+	if !utf8.Valid(bs) {
+		return ErrInvalidUTF8
+	}
+
+	return e.encodeBytes(TypeText, bs)
+}
+
+func (e Encoder) EncodeArrayHeader(n int) error {
+	/*
+	   Major type 4:  an array of data items.  Arrays are also called lists,
+	       sequences, or tuples.  The array's length follows the rules for
+	       byte strings (major type 2), except that the length denotes the
+	       number of data items, not the length in bytes that the array takes
+	       up.  Items in an array do not need to all be of the same type.
+	       For example, an array that contains 10 items of any type would
+	       have an initial byte of 0b100_01010 (major type of 4, additional
+	       information of 10 for the length) followed by the 10 remaining
+	       items.
+	*/
+
+	return e.encodeTypedUInt(TypeArray, uint64(n))
+}
+
+func (e Encoder) EncodeBool(b bool) error {
+	var ai byte
+	switch b {
+	case true:
+		// True (major type 7, additional information 21)
+		ai = 21
+	case false:
+		// False (major type 7, additional information 20)
+		ai = 20
+	}
+
+	bs := []byte{byte(TypeOther) | ai}
+	if _, err := e.w.Write(bs); err != nil {
+		return err
+	}
+	return nil
+}
+
+type MapEntryEncoder struct {
+	keyBuf   bytes.Buffer
+	valueBuf bytes.Buffer
+
+	KeyE   Encoder
+	ValueE Encoder
+}
+
+func NewMapEntry() *MapEntryEncoder {
+	e := &MapEntryEncoder{}
+
+	e.KeyE = Encoder{&e.keyBuf}
+	e.ValueE = Encoder{&e.valueBuf}
+
+	return e
+}
+
+func GenerateMapEntry(f func(keyE Encoder, valueE Encoder)) *MapEntryEncoder {
+	e := NewMapEntry()
+	f(e.KeyE, e.ValueE)
+	return e
+}
+
+type MapEntryEncoderSorter []*MapEntryEncoder
+
+var _ = sort.Interface(MapEntryEncoderSorter{})
+
+func (s MapEntryEncoderSorter) Len() int { return len(s) }
+func (s MapEntryEncoderSorter) Less(i, j int) bool {
+	return bytes.Compare(s[i].keyBuf.Bytes(), s[j].keyBuf.Bytes()) < 0
+}
+func (s MapEntryEncoderSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (e *Encoder) EncodeMap(mes []*MapEntryEncoder) error {
+	if err := e.encodeTypedUInt(TypeMap, uint64(len(mes))); err != nil {
+		return err
+	}
+	for _, me := range mes {
+		if _, err := io.Copy(e.w, &me.keyBuf); err != nil {
+			return err
+		}
+		if _, err := io.Copy(e.w, &me.valueBuf); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/go/signedexchange/cbor/encoder_test.go
+++ b/go/signedexchange/cbor/encoder_test.go
@@ -3,6 +3,7 @@ package cbor
 import (
 	"bytes"
 	"encoding/hex"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -16,7 +17,7 @@ func fromHex(h string) []byte {
 	return bytes
 }
 
-func TestIntegers(t *testing.T) {
+func TestEncodeInt(t *testing.T) {
 	var inttests = []struct {
 		i        int64
 		encoding string
@@ -46,10 +47,139 @@ func TestIntegers(t *testing.T) {
 		if err := e.EncodeInt(test.i); err != nil {
 			t.Errorf("Encode. err: %v", err)
 		}
-		expected := fromHex(test.encoding)
+		exp := fromHex(test.encoding)
 
-		if !bytes.Equal(expected, b.Bytes()) {
-			t.Errorf("%d expected to encode to %v, actual %v", test.i, expected, b.Bytes())
+		if !bytes.Equal(exp, b.Bytes()) {
+			t.Errorf("%d expected to encode to %v, actual %v", test.i, exp, b.Bytes())
 		}
+	}
+}
+
+func TestEncodeByteString(t *testing.T) {
+	var bytesTests = []struct {
+		bs       []byte
+		encoding string
+	}{
+		{[]byte{}, "60"},
+		{[]byte{0xab}, "41ab"},
+		{
+			[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
+			"5818 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17",
+		},
+	}
+	// This doesn't test every size of integer that might encode the length
+	// of the byte string.
+
+	for _, test := range textTests {
+		var b bytes.Buffer
+		e := &Encoder{&b}
+
+		if err := e.EncodeByteString(test.bs); err != nil {
+			t.Errorf("Encode. err: %v", err)
+		}
+		exp := fromHex(test.encoding)
+
+		if !bytes.Equal(exp, b.Bytes()) {
+			t.Errorf("%v expected to encode to %v, actual %v", test.bs, exp, b.Bytes())
+		}
+	}
+}
+
+func TestEncodeTextString(t *testing.T) {
+	var textTests = []struct {
+		s        string
+		encoding string
+	}{
+		{"", "60"},
+		{"a", "6161"},
+		{"IETF", "6449455446"},
+		{`"\`, "62225c"},
+		{"\u00fc", "62c3bc"},
+		{"\u6c34", "63e6b0b4"},
+		{"\U00010151", "64f0908591"},
+	}
+	for _, test := range textTests {
+		var b bytes.Buffer
+		e := &Encoder{&b}
+
+		if err := e.EncodeTextString(test.s); err != nil {
+			t.Errorf("Encode. err: %v", err)
+		}
+		exp := fromHex(test.encoding)
+
+		if !bytes.Equal(exp, b.Bytes()) {
+			t.Errorf("\"%s\" expected to encode to %v, actual %v", test.s, exp, b.Bytes())
+		}
+	}
+}
+
+func TestMapEncoderSorter(t *testing.T) {
+	/*
+	  The keys in every map MUST be sorted in the bytewise lexicographic order of their canonical encodings. For example, the following keys are correctly sorted:
+	  1. 10, encoded as 0A.
+	  2. 100, encoded as 18 64.
+	  3. -1, encoded as 20.
+	  4. “z”, encoded as 61 7A.
+	  5. “aa”, encoded as 62 61 61.
+	  6. [100], encoded as 81 18 64.
+	  7. [-1], encoded as 81 20.
+	  8. false, encoded as F4.
+	*/
+
+	es := []*MapEntryEncoder{
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeInt(10)
+			valueE.EncodeTextString("int 10")
+		}),
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeInt(100)
+			valueE.EncodeTextString("int 100")
+		}),
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeInt(-1)
+			valueE.EncodeTextString("int -1")
+		}),
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeTextString("z")
+			valueE.EncodeTextString("string \"z\"")
+		}),
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeTextString("aa")
+			valueE.EncodeTextString("string \"aa\"")
+		}),
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeArrayHeader(1)
+			keyE.EncodeInt(100)
+			valueE.EncodeTextString("array [100]")
+		}),
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeArrayHeader(1)
+			keyE.EncodeInt(-1)
+			valueE.EncodeTextString("array [-1]")
+		}),
+		GenerateMapEntry(func(keyE Encoder, valueE Encoder) {
+			keyE.EncodeBool(false)
+			valueE.EncodeTextString("false")
+		}),
+	}
+
+	keyExp := [][]byte{
+		fromHex("0A"),
+		fromHex("18 64"),
+		fromHex("20"),
+		fromHex("61 7A"),
+		fromHex("62 61 61"),
+		fromHex("81 18 64"),
+		fromHex("81 20"),
+		fromHex("F4"),
+	}
+	for i, exp := range keyExp {
+		if !bytes.Equal(exp, es[i].keyBuf.Bytes()) {
+			t.Errorf("FAIL key %d expected to encode to %v, actual %v ", i, exp, es[i].keyBuf.Bytes())
+		}
+	}
+
+	if !sort.IsSorted(MapEntryEncoderSorter(es)) {
+		t.Errorf("FAIL")
 	}
 }


### PR DESCRIPTION
PTAL