### PR TITLE
Return error if request headers are too big.

### DIFF
--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -156,6 +156,9 @@ func WriteExchangeFile(w io.Writer, e *Exchange) error {
 	// 1. The first 3 bytes of the content represents the length of the CBOR
 	// encoded section, encoded in network byte (big-endian) order.
 	cborBytes := buf.Bytes()
+	if len(cborBytes) >> 24 != 0 {
+		return fmt.Errorf("signedexchange: request headers too big: %d bytes", len(cborBytes))
+	}
 	if _, err := w.Write([]byte{
 		byte(len(cborBytes) >> 16),
 		byte(len(cborBytes) >> 8),

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/ugorji/go/codec"
 
-	. "github.com/WICG/webpackage/go/signedexchange"
+	. "github.com/nyaxt/webpackage/go/signedexchange"
 )
 
 const (
@@ -234,5 +234,18 @@ func TestSignedExchange(t *testing.T) {
 	// Payload part
 	if gotPayload := binExchange[3+cborLength:]; !bytes.Equal(gotPayload, expectedEncodedPayload) {
 		t.Errorf("payload:\ngot %q,\nwant %q", gotPayload, expectedEncodedPayload)
+	}
+}
+
+func TestRequestHeadersTooBig(t *testing.T) {
+	u, _ := url.Parse("https://example.com/")
+	e, err := NewExchange(u, http.Header{"foo": []string{strings.Repeat(".", 1 << 25)}}, 200, http.Header{}, []byte(""), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err = WriteExchangeFile(&buf, e)
+	if err == nil {
+		t.Error("expected error")
 	}
 }


### PR DESCRIPTION
The request headers must be small enough for their length to be
encodable in 3 bytes. 16MB is an unusually large size, but it doesn't
hurt to guard against unusual input.