### PR TITLE
Change header length limit to 512kB, per spec.

### DIFF
--- a/go/signedexchange/signedexchange.go
+++ b/go/signedexchange/signedexchange.go
@@ -156,7 +156,7 @@ func WriteExchangeFile(w io.Writer, e *Exchange) error {
 	// 1. The first 3 bytes of the content represents the length of the CBOR
 	// encoded section, encoded in network byte (big-endian) order.
 	cborBytes := buf.Bytes()
-	if len(cborBytes) >= 1 << 24 {
+	if len(cborBytes) >= 524288 {
 		return fmt.Errorf("signedexchange: request headers too big: %d bytes", len(cborBytes))
 	}
 	if _, err := w.Write([]byte{

--- a/go/signedexchange/signedexchange_test.go
+++ b/go/signedexchange/signedexchange_test.go
@@ -239,7 +239,7 @@ func TestSignedExchange(t *testing.T) {
 
 func TestRequestHeadersTooBig(t *testing.T) {
 	u, _ := url.Parse("https://example.com/")
-	e, err := NewExchange(u, http.Header{"foo": []string{strings.Repeat(".", 1 << 25)}}, 200, http.Header{}, []byte(""), 16)
+	e, err := NewExchange(u, http.Header{"foo": []string{strings.Repeat(".", 1 << 19)}}, 200, http.Header{}, []byte(""), 16)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Change the cborBytes limit from 1<<24 (16M) to 1<<19 (512k), as is
called for by
https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#application-signed-exchange

I had misread this in my previous commit; sorry!